### PR TITLE
chore(scripts): Switched back to npm publish

### DIFF
--- a/package-scripts.js
+++ b/package-scripts.js
@@ -69,7 +69,7 @@ module.exports = {
       description: 'We automate releases with semantic-release. This should only be run on travis',
       script: series(
         'semantic-release pre',
-        'yarn publish',
+        'npm publish',
         'semantic-release post'
       ),
     },


### PR DESCRIPTION

- [x] Bug

Past configuration running `yarn publish` was producing a query for the owner to respond to during the travis build which obviously cannot be interacted with causing a stall & failure of the build. Switched back to `npm publish`.